### PR TITLE
chore(goreleaser): exclude chore commits from changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,7 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+      - "^chore:"
 
 release:
   footer: >-


### PR DESCRIPTION
### What

This PR updates `.goreleaser.yaml` to exclude `chore:` commits from the generated changelog.

### Why

Commits of type `chore` are typically related to maintenance tasks (e.g., CI, config) and don't need to appear in the release changelog.

This keeps the changelog focused on changes relevant to users, like features and bug fixes.
