### PR TITLE
chore(ci): add GitHub Actions workflow for Go tests and Codecov integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Go Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests with coverage
+        run: go test -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description
Add a GitHub Actions workflow to automate running Go tests and uploading coverage reports to Codecov.

- Runs on push to main and on pull requests targeting main
- Runs tests generating coverage profile coverage.txt
- Uploads coverage report to Codecov using CODECOV_TOKEN secret

This setup improves CI automation and code coverage tracking, providing detailed
coverage insights directly in pull requests.
