### PR TITLE
chore(makefile): add test and coverage targets for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,10 @@ run:
 
 release-local:
 	docker compose run --rm releaser release --snapshot --clean
+
+test:
+	docker compose run --rm dev go test -coverprofile=coverage.out ./...
+
+coverage: test
+	docker compose run --rm dev go tool cover -html=coverage.out -o coverage.html
+	open coverage.html || xdg-open coverage.html || start coverage.html

--- a/README.md
+++ b/README.md
@@ -43,19 +43,29 @@ git clone https://github.com/gabrieldeespindula/calq.git
 cd calq
 ```
 
-2. To build the binary:
-
-```bash
-make build
-```
-
-3. To run the project without building:
+2. To run the project:
 
 ```bash
 make run
 ```
 
 These commands run Go inside a Docker container to provide a clean and reproducible environment.
+
+---
+
+### Running Tests Locally
+
+To run tests and check code coverage locally, use:
+
+```bash
+make test
+```
+Run tests and generate coverage.out
+
+```bash
+make coverage
+```
+Run tests, generate and open coverage.html
 
 ---
 


### PR DESCRIPTION
## Description

This PR adds two new targets to the `Makefile`:

* `test`: runs the tests and generates the `coverage.out` file.
* `coverage`: depends on `test`, generates a `coverage.html` file, and attempts to open it automatically (`open`, `xdg-open`, `start`).

These commands enhance the local development workflow by making it easier to run tests with coverage in a consistent way. They are not currently used in CI, keeping a clear separation between local development and automation processes.

Usage example:

```bash
make test
```

Runs tests and generates `coverage.out`.

```bash
make coverage
```

Runs tests, generates, and opens `coverage.html`.

Additionally, the README is updated with instructions on how to use these commands for local development.