### PR TITLE
refactor(repl): extract REPL logic from main into repl package

### DIFF
--- a/cmd/calq/main.go
+++ b/cmd/calq/main.go
@@ -1,46 +1,12 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
 	"os"
-	"strings"
-	"calq/internal/calculator"
+	"calq/internal/repl"
 )
 
 var Version = "dev"
 
 func main() {
-	var lastResult string
-	reader := bufio.NewReader(os.Stdin)
-
-	fmt.Println("Welcome to calq! Type your expressions (Ctrl+C to exit):")
-	for {
-		fmt.Print("> ")
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			fmt.Println("Input error:", err)
-			continue
-		}
-
-		input = strings.TrimSpace(input)
-		if input == "" {
-			continue
-		}
-
-		tokens, err := calculator.Tokenize(input, lastResult)
-		if err != nil {
-			fmt.Println("Tokenize error:", err)
-			continue
-		}
-
-		result, err := calculator.Evaluate(tokens)
-		if err != nil {
-			fmt.Println("Evaluation error:", err)
-			continue
-		}
-
-		lastResult = fmt.Sprintf("%f", result)
-		fmt.Println(result)
-	}
+	repl.Run(os.Stdin, os.Stdout)
 }

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -1,0 +1,50 @@
+package repl
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"calq/internal/calculator"
+)
+
+func Run(in io.Reader, out io.Writer) {
+	var lastResult string
+	reader := bufio.NewReader(in)
+
+	fmt.Fprintln(out, "Welcome to calq! Type your expressions (Ctrl+C to exit):")
+	for {
+		fmt.Fprint(out, "> ")
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Fprintln(out, "Input error:", err)
+			continue
+		}
+
+		input = strings.TrimSpace(input)
+		if input == "" {
+			continue
+		}
+
+		if strings.EqualFold(input, "q") {
+			fmt.Fprintln(out, "Goodbye!")
+			break
+		}
+
+		tokens, err := calculator.Tokenize(input, lastResult)
+		if err != nil {
+			fmt.Fprintln(out, "Tokenize error:", err)
+			continue
+		}
+
+		result, err := calculator.Evaluate(tokens)
+		if err != nil {
+			fmt.Fprintln(out, "Evaluation error:", err)
+			continue
+		}
+
+		lastResult = fmt.Sprintf("%f", result)
+		fmt.Fprintln(out, result)
+	}
+}

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -1,0 +1,42 @@
+package repl
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    string
+	}{
+		{"2 + 2\n", "4"},
+		{"5 - 2\n", "3"},
+		{"4 * 3\n", "12"},
+		{"10 / 2\n", "5"},
+		{"3 + 5 * 2\n", "13"},
+		{"2 + 10 / 2\n+3\n", "> 7\n> 10"},
+		{"2 + 10 / 2\n2+3\n", "> 7\n> 5"},
+		{"20*j\n", "Evaluation error: invalid number: j"},
+		{"\n", "Welcome to calq! Type your expressions (Ctrl+C to exit):\n> > Goodbye!\n"},
+	}
+
+	for _, tt := range tests {
+		input := strings.NewReader(tt.input+"q\n")
+		output := &bytes.Buffer{}
+
+		Run(input, output)
+
+		got := output.String()
+		if !strings.Contains(got, "Welcome to calq! Type your expressions (Ctrl+C to exit):") {
+			t.Errorf("expected welcome message, got %q", got)
+		}
+		if !strings.Contains(got, tt.expected) {
+			t.Errorf("expected output to contain '%s', got %q", tt.expected, got)
+		}
+		if !strings.Contains(got, "Goodbye!") {
+			t.Errorf("expected goodbye message, got %q", got)
+		}
+	}
+}


### PR DESCRIPTION
### Description
This PR refactors the application by extracting the REPL (Read-Eval-Print Loop) 
logic from the main package into a dedicated repl package.

- The REPL logic now accepts io.Reader and io.Writer interfaces, allowing for 
  easier automated testing and input/output control.
- Added support for quitting the REPL by typing 'q'.
- The main package is simplified, focusing on bootstrapping the application.
- This improves code modularity, maintainability, and testability of the CLI interface.

