### PR TITLE
feat(flags): add --version and -v flags to display CLI version

### DIFF
--- a/cmd/calq/main.go
+++ b/cmd/calq/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"os"
 	"calq/internal/repl"
 )
@@ -8,5 +10,15 @@ import (
 var Version = "dev"
 
 func main() {
+	showVersion := flag.Bool("version", false, "Print version information")
+  showVersionShort := flag.Bool("v", false, "Print version information (shorthand)")
+
+  flag.Parse()
+
+	if *showVersion || *showVersionShort {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
 	repl.Run(os.Stdin, os.Stdout)
 }


### PR DESCRIPTION
Closes #10

### Description

This adds support for displaying the current CLI version using --version or -v. Helps users quickly verify which version they are running.

---

### Checklist

- [ ] Code has been tested
- [x] PR is small and focused
- [ ] CI pipeline passes
- [ ] Documentation has been updated if necessary

---

### Screenshots or GIFs (if applicable)

<!-- Attach visuals to help reviewers understand the change -->

---

### Related Issues / References

<!-- Link to related issues, tickets, or external references -->
