### PR TITLE
feat(cli): add eval mode support for single expression calculations

### DIFF
--- a/e2e/flags_test.go
+++ b/e2e/flags_test.go
@@ -16,6 +16,39 @@ func TestLongVersionFlag(t *testing.T) {
 	runCalqVersionFlag(t, "--version")
 }
 
+func TestEvalMultipleExpressions(t *testing.T) {
+    tests := []struct {
+        expr     string
+        expected string
+    }{
+        {"1+1", "2"},
+        {"2*3", "6"},
+        {"10/3", "3.33"},
+        {"5-3", "2"},
+        {"2+2*2", "6"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.expr, func(t *testing.T) {
+            cmd := exec.Command("../calq", "--eval", tt.expr)
+
+            var out bytes.Buffer
+            cmd.Stdout = &out
+            cmd.Stderr = &out
+
+            err := cmd.Run()
+            if err != nil {
+                t.Fatalf("failed to run calq with expression %q: %v", tt.expr, err)
+            }
+
+            output := out.String()
+            if !strings.Contains(output, tt.expected) {
+                t.Errorf("output for %q does not contain expected result %q: got %q", tt.expr, tt.expected, output)
+            }
+        })
+    }
+}
+
 
 func runCalqVersionFlag(t *testing.T, flag string) {
 	t.Helper()

--- a/e2e/flags_test.go
+++ b/e2e/flags_test.go
@@ -14,8 +14,8 @@ func TestVersionFlag(t *testing.T) {
 }
 
 func TestEvalFlag(t *testing.T) {
-	testEvalMultipleExpressions(t, "--eval")
-	testEvalMultipleExpressions(t, "-e")
+	runCalqEvalFlag(t, "--eval")
+	runCalqEvalFlag(t, "-e")
 }
 
 

--- a/e2e/flags_test.go
+++ b/e2e/flags_test.go
@@ -8,15 +8,18 @@ import (
 )
 
 
-func TestShortVersionFlag(t *testing.T) {
+func TestVersionFlag(t *testing.T) {
+	runCalqVersionFlag(t, "--version")
 	runCalqVersionFlag(t, "-v")
 }
 
-func TestLongVersionFlag(t *testing.T) {
-	runCalqVersionFlag(t, "--version")
+func TestEvalFlag(t *testing.T) {
+	testEvalMultipleExpressions(t, "--eval")
+	testEvalMultipleExpressions(t, "-e")
 }
 
-func TestEvalMultipleExpressions(t *testing.T) {
+
+func runCalqEvalFlag(t *testing.T, flag string) {
     tests := []struct {
         expr     string
         expected string
@@ -30,7 +33,7 @@ func TestEvalMultipleExpressions(t *testing.T) {
 
     for _, tt := range tests {
         t.Run(tt.expr, func(t *testing.T) {
-            cmd := exec.Command("../calq", "--eval", tt.expr)
+            cmd := exec.Command("../calq", flag, tt.expr)
 
             var out bytes.Buffer
             cmd.Stdout = &out

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"runtime"
+	"calq/internal/calculator"
 )
 
 type VersionInfo struct {
@@ -15,10 +16,23 @@ type VersionInfo struct {
 func RunParse(info VersionInfo, runApp func()) int {
     showVersion := flag.Bool("version", false, "show the current version")
     showShort := flag.Bool("v", false, "show the current version (short)")
+	evalMode := flag.String("eval", "", "run in eval mode with a single expression (e.g. '1+1')")
+
     flag.Parse()
 
     if *showVersion || *showShort {
         printVersion(info)
+        return 0
+    }
+
+    if *evalMode != "" {
+		result, err := calculator.Calculate("", *evalMode)
+		if err != nil {
+			fmt.Printf("Calculation error: %v\n", err)
+			return 1
+		}
+
+		fmt.Printf("%.2f\n", result)
         return 0
     }
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -13,10 +13,11 @@ type VersionInfo struct {
 	Date    string
 }
 
-func RunParse(info VersionInfo, runApp func()) int {
+func RunParse(info VersionInfo, runApp func()) int {	
     showVersion := flag.Bool("version", false, "show the current version")
     showShort := flag.Bool("v", false, "show the current version (short)")
 	evalMode := flag.String("eval", "", "run in eval mode with a single expression (e.g. '1+1')")
+	evalModeShort := flag.String("e", "", "run in eval mode with a single expression (e.g. '1+1')")
 
     flag.Parse()
 
@@ -25,15 +26,19 @@ func RunParse(info VersionInfo, runApp func()) int {
         return 0
     }
 
-    if *evalMode != "" {
-		result, err := calculator.Calculate("", *evalMode)
+    if *evalMode != "" || *evalModeShort != "" {
+		expr := *evalMode
+		if expr == "" {
+			expr = *evalModeShort
+		}
+	
+		result, err := calculator.Calculate("", expr)
 		if err != nil {
 			fmt.Printf("Calculation error: %v\n", err)
 			return 1
 		}
-
 		fmt.Printf("%.2f\n", result)
-        return 0
+		return 0
     }
 
     runApp()


### PR DESCRIPTION
## Add `--eval` and `-e` flags to evaluate expressions directly via CLI

### Summary

This PR introduces a new command-line flag `--eval` (short `-e`) that allows users to pass a mathematical expression directly as an argument to the `calq` binary and get the evaluated result immediately.

### What was added

* Support for the `--eval` flag and its shorthand `-e` in the CLI.
* When either `--eval` or `-e` is used, `calq` evaluates the given expression and prints the result with two decimal places.
* Added E2E tests to verify the correctness of the `--eval` flag with multiple arithmetic expressions.

### Example usage

```bash
./calq --eval "2+3"
# Output:
5.00

./calq -e "10/2"
# Output:
5.00
```

### Motivation

This feature improves usability by allowing quick calculations directly from the command line without entering the interactive REPL mode. It's useful for scripting or quick math operations.

### Testing

* Added automated integration (E2E) tests that run the binary with different expressions and check the output.
* Tests ensure the `--eval` and `-e` flags work correctly with various operations such as addition, subtraction, multiplication, and division.